### PR TITLE
removing my name and association with the library of congress

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,4 +6,4 @@ title: Introduction
 Best practices are difficult to practice without a good environment in which to practice them. 
 Here we enumerate the elements of a productive development environment.
 
-The content of this guide is primarily authored by [John Scancella](https://github.com/johnscancella) of the Library of Congress. 18F appreciates and welcomes outside content contributions; getting involved is as simple as [filing an issue](https://github.com/18F/dev-environment/issues) or providing a [pull request](https://github.com/18F/dev-environment/pulls?q=is%3Apr+author%3Ajohnscancella+is%3Aclosed) with your ideas!
+18F appreciates and welcomes outside content contributions; getting involved is as simple as [filing an issue](https://github.com/18F/dev-environment/issues) or providing a [pull request](https://github.com/18F/dev-environment/pulls?q=is%3Apr+author%3Ajohnscancella+is%3Aclosed) with your ideas!


### PR DESCRIPTION
I would rather not have my name and the association with the library of congress on the guide.
