### PR TITLE
Fixing typo ("alloction") on "Self provisioning"

### DIFF
--- a/pages/self-provisioning.md
+++ b/pages/self-provisioning.md
@@ -4,7 +4,7 @@ layout: default
 title: Self provisioning
 ---
 <a name="self-provisioning"></a>
-Developers can create and delete systems on demand, with group alloction and quotas as needed to avoid overcommiting resources. 
+Developers can create and delete systems on demand, with group allocation and quotas as needed to avoid overcommiting resources. 
 These self-provisioned systems are identical with documented exceptions for network configuration, authentication, etc. 
 All services should be developed using SSL for proper testing. 
 This requires a self-service system to issue certificates, so applications can be developed and tested using the same configuration used in production.


### PR DESCRIPTION
Just "alloction" to "allocation".
